### PR TITLE
Base parent span features and increased test coverage 

### DIFF
--- a/span.go
+++ b/span.go
@@ -18,14 +18,15 @@ package money
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"time"
 )
 
-//Span models all the data related to a Span
-//It is a superset to what is specified in the
-//spec: https://github.com/Comcast/money/wiki#what-is-captured
+// Span models all the data related to a Span
+// It is a superset to what is specified in the
+// spec: https://github.com/Comcast/money/wiki#what-is-captured
 type Span struct {
 	//the user gives us these values
 	Name    string
@@ -41,51 +42,107 @@ type Span struct {
 	Host      string
 }
 
-// Result models the result fields of a span.  The zero value of this struct
-// indicates a successful span execution.
+// Result models the result fields of a span.
 type Result struct {
-	//Name of the Span (i.e HTTPHandler)
+	// Name of the Span (i.e HTTPHandler)
 	Name string
 
-	//Name of the application/service running the Span (i.e. Scytale in XMiDT)
+	// Start Time
+
+	// Name of the application/service running the Span (i.e. Scytale in XMiDT)
 	AppName string
 
-	//whether or not this span is defined as "successful"
-	Success bool
+	// StartTime
 
 	// Code is an abstract value which is up to the span code to supply.
 	// It is not necessary to enforce that this is an HTTP status code.
 	// The translation into an HTTP status code should take place elsewhere.
 	Code int
 
-	// Err is just the error reported by the span
+	// Whether or not this span is defined as "successful"
+	Success bool
+
 	Err error
+
+	StartTime time.Time
+
+	Duration time.Duration
+
+	Host string
 }
 
-//String() returns the string representation of the span
+// NewSpan returns a new span instance.
+func NewSpan(spanName string, tc *TraceContext) Span {
+	return Span{
+		Name: spanName,
+		TC:   tc,
+	}
+}
+
+type SpanMap map[string]string
+
+// Changes a maps values to type string.
+func mapFieldToString(m map[string]interface{}) SpanMap {
+	n := make(map[string]string)
+
+	for k, v := range m {
+		switch v.(type) {
+		case float64:
+			if k == "Duration" {
+				var i = int64(m[k].(float64))
+				var d = time.Duration(i).Nanoseconds()
+				n[k] = fmt.Sprintf("%v"+"ns", d)
+			} else if k == "Code" {
+				n[k] = fmt.Sprintf("%.f", m[k].(float64))
+			}
+		case bool:
+			n[k] = strconv.FormatBool(m[k].(bool))
+		case string:
+			n[k] = m[k].(string)
+		case map[string]interface{}:
+			if k == "TC" {
+				n[k] = encodeTC(m[k])
+			} else if k == "Err" {
+				n[k] = "Error"
+			}
+		}
+	}
+
+	return n
+}
+
+// Map returns a string map representation of the span
+func (s *Span) Map() (SpanMap, error) {
+	var m map[string]interface{}
+
+	// Receive a map of string to objects
+	r, err := json.Marshal(s)
+	if err != nil {
+		return nil, err
+	}
+
+	json.Unmarshal(r, &m)
+
+	return mapFieldToString(m), nil
+}
+
+// String returns the string representation of the span
 func (s *Span) String() string {
 	var o = new(bytes.Buffer)
 
 	o.WriteString("span-name=" + s.Name)
 	o.WriteString(";app-name=" + s.AppName)
-	o.WriteString(";span-duration=" + strconv.FormatInt(s.Duration.Nanoseconds()/1e3, 10)) //span duration in microseconds
+	o.WriteString(";span-duration=" + fmt.Sprintf("%v"+"ns", s.Duration.Nanoseconds()))
 	o.WriteString(";span-success=" + strconv.FormatBool(s.Success))
-
-	o.WriteString(";span-id=" + strconv.FormatInt(int64(s.TC.SID), 10))
-	o.WriteString(";trace-id=" + s.TC.TID)
-	o.WriteString(";parent-id=" + strconv.FormatInt(int64(s.TC.PID), 10))
-
-	o.WriteString(fmt.Sprintf(";start-time=%v", s.StartTime.UTC().UnixNano()/1e3)) //UTC time since epoch in microseconds
+	o.WriteString(";" + encodeTraceContext(s.TC))
+	o.WriteString(";start-time=" + s.StartTime.Format("2006-01-02T15:04:05.999999999Z07:00"))
 
 	if s.Host != "" {
 		o.WriteString(";host=" + s.Host)
 	}
 
-	//TODO: in the Result struct used to fill Spans, we say it's ok for s.Code not to be an HTTP status code
-	//but according to the specs, the code we return as string is assumed to be of such kind
-	//let's avoid contradictions here
 	if s.Code != 0 {
-		o.WriteString(fmt.Sprintf(";http-response-code=%v", s.Code))
+		o.WriteString(fmt.Sprintf(";response-code=%v", s.Code))
 	}
 
 	if s.Err != nil {

--- a/span.go
+++ b/span.go
@@ -101,7 +101,7 @@ func mapFieldToString(m map[string]interface{}) SpanMap {
 			n[k] = m[k].(string)
 		case map[string]interface{}:
 			if k == "TC" {
-				n[k] = encodeTC(m[k])
+				n[k] = typeInferenceTC(m[k])
 			} else if k == "Err" {
 				n[k] = "Error"
 			}

--- a/trace.go
+++ b/trace.go
@@ -76,14 +76,10 @@ func decodeTraceContext(raw string) (tc *TraceContext, err error) {
 }
 
 // encodeTraceContext returns a concatenated string of all field values that exist in a trace context.
-func encodeTC(tc interface{}) string {
+func typeInferenceTC(tc interface{}) string {
 	tcs := tc.(map[string]interface{})
 
-	m := map[string]string{
-		"PID": "",
-		"SID": "",
-		"TID": "",
-	}
+	m := map[string]string{}
 
 	for k, v := range tcs {
 		switch v.(type) {
@@ -99,10 +95,6 @@ func encodeTC(tc interface{}) string {
 	return fmt.Sprintf("%s=%v;%s=%v;%s=%v", pIDKey, m["PID"], sIDKey, m["SID"], tIDKey, m["TID"])
 }
 
-/*
-	fmt.Sprintf("%s=%v;%s=%v;%s=%v", pIDKey, tc[PID].(float64), sIDKey, tc[SID].(float64), tIDKey, tc[TID].(string))
-*/
-
 // EncodeTraceContext encodes the TraceContext into a string.
 func encodeTraceContext(tc *TraceContext) string {
 	return fmt.Sprintf("%s=%v;%s=%v;%s=%v", pIDKey, tc.PID, sIDKey, tc.SID, tIDKey, tc.TID)
@@ -110,7 +102,7 @@ func encodeTraceContext(tc *TraceContext) string {
 
 // This is useful if you want to pass your trace context over an outgoing request or just need a string formatted trace context for any other purpose.
 func EncodeTraceContext(tc *TraceContext) string {
-	return fmt.Sprintf("%s=%v;%s=%v;%s=%v", pIDKey, tc.PID, sIDKey, tc.SID, tIDKey, tc.TID)
+	return encodeTraceContext(tc)
 }
 
 // SubTrace creates a child trace context for current

--- a/trace.go
+++ b/trace.go
@@ -75,7 +75,7 @@ func decodeTraceContext(raw string) (tc *TraceContext, err error) {
 	return
 }
 
-// encodeTraceContext returns a concatenated string of all field values that exist in a trace context.
+// typeInferenceTC  returns a concatenated string of all field values that exist in a trace context from a map[string]interface{}
 func typeInferenceTC(tc interface{}) string {
 	tcs := tc.(map[string]interface{})
 

--- a/trace_test.go
+++ b/trace_test.go
@@ -82,7 +82,7 @@ func TestDecodeTraceContextOtherCases(t *testing.T) {
 
 //TODO: need to if a string is in the right order accordance.
 // Tests if encodeTraceContext outputs a the fields of a TID in the correct order.
-func TestEncodeTC(t *testing.T) {
+func TestTypeInferenceTC(t *testing.T) {
 	in := map[string]interface{}{
 		"PID": 1,
 		"SID": 1,
@@ -90,7 +90,7 @@ func TestEncodeTC(t *testing.T) {
 	}
 
 	var expected = "parent-id=1;span-id=1;trace-id=one"
-	var actual = encodeTC(in)
+	var actual = typeInferenceTC(in)
 
 	if actual != expected {
 		t.Errorf("Wrong Format for Trace Context string, need '%v' but got '%v'", expected, actual)

--- a/trace_test.go
+++ b/trace_test.go
@@ -81,7 +81,7 @@ func TestDecodeTraceContextOtherCases(t *testing.T) {
 }
 
 //TODO: need to if a string is in the right order accordance.
-// Tests if encodeTraceContext outputs a the fields of a TID in the correct order.
+// Tests if typeInferenceTC  outputs a the fields of a TID in the correct order.
 func TestTypeInferenceTC(t *testing.T) {
 	in := map[string]interface{}{
 		"PID": 1,

--- a/trace_test.go
+++ b/trace_test.go
@@ -80,6 +80,23 @@ func TestDecodeTraceContextOtherCases(t *testing.T) {
 	})
 }
 
+//TODO: need to if a string is in the right order accordance.
+// Tests if encodeTraceContext outputs a the fields of a TID in the correct order.
+func TestEncodeTC(t *testing.T) {
+	in := map[string]interface{}{
+		"PID": 1,
+		"SID": 1,
+		"TID": "one",
+	}
+
+	var expected = "parent-id=1;span-id=1;trace-id=one"
+	var actual = encodeTC(in)
+
+	if actual != expected {
+		t.Errorf("Wrong Format for Trace Context string, need '%v' but got '%v'", expected, actual)
+	}
+}
+
 func TestEncodeTraceContext(t *testing.T) {
 	in := &TraceContext{
 		PID: 1,


### PR DESCRIPTION
Changes include: 

1. Span
- `SpanMap`: new object of type map[string]string that represents a span's map. 
- `NewSpan()`: spits out span instance.
- `mapFieldToString()`: changes a map[string]interface{} to a map[string]string.  
- `Map()`: uses json package and `mapFieldToString()` to flatten a span object to type SpanMap .
-  Small refactor.

2. Trace
- `typeInferenceTC()`: wrangles a trace context, string[string]interface{} type, to a map[string]string.  Used within `mapFieldToString()`
- `encodeTraceContext()`: used internally within `EncodeTraceContext()` and span's `String()`
- Small refactor. 

3. Increased test coverage 